### PR TITLE
Include Antora version adjustment for release workflow

### DIFF
--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -50,10 +50,14 @@ jobs:
           git fetch
           git checkout -b $release_branch_name --track origin/$release_branch_name || true
           git checkout -b $release_branch_name
-      - name: Set version
+      - name: Set Maven version
         run: |
           mvn versions:set -DnewVersion=${{ github.event.inputs.release_version }}
           mvn versions:commit
+      - name: Set Antora version
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq eval -i '.version = "${{ github.event.inputs.release_version }}"' documentation/developer-guide/antora.yml
       - name: Commit version changes and push to upstream repository
         run: |
           git add .


### PR DESCRIPTION
This PR adds an update step to the SDK release workflow that adjusts the Antora version property to match the Maven version.

Closes #67