### PR TITLE
Do not generate @NotNull for notInPayload properties

### DIFF
--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-property-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-property-lib.vm
@@ -1,6 +1,6 @@
 #macro( javaPojoProperty $property )
 #set( $propertyType = $util.getPropertyType( $property, true, $codeGenerationConfig ) )
-#if( !$property.isOptional() )
+#if( !$property.isOptional() && !$property.isNotInPayload() )
     $codeGenerationConfig.getImportTracker().importExplicit( $NotNull )
 @NotNull
 #end

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -227,7 +227,13 @@ public class AspectModelJavaGeneratorTest extends MetaModelVersions {
             .findAll( ConstructorDeclaration.class );
       assertThat( constructorDeclarations ).hasSize( 2 );
 
-      result.assertFields( "EvaluationResult", expectedFieldsForEvaluationResults, new HashMap<>() );
+      result.assertFields( "EvaluationResult", expectedFieldsForEvaluationResults, ImmutableMap.<String, String> builder()
+            .put( "average", "" )
+            .put( "numericCode", "@NotNull" )
+            .put( "description", "" )
+            .put( "nestedResult", "@NotNull" )
+            .build()
+      );
       result.assertConstructor( "EvaluationResult", expectedFieldsForEvaluationResults, new HashMap<>() );
 
       final ConstructorDeclaration jacksonConstructor = constructorDeclarations.get( 1 );


### PR DESCRIPTION
Properties which are defined as not being part of the payload are no
longer annotated with @NotNull in the generated POJOs. This was
unnecessary and inconsistent.
The generated class for an Entity with a Property which is not part of
the payload contains a constructor which does not include this Property,
used for deserialization. Hence the generated class contained a member
variable annotated with @NotNull which is not set in the constructor.

fixes #42