### PR TITLE
Escape regex literals in generated Java code

### DIFF
--- a/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
+++ b/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/json/AspectModelJsonPayloadGeneratorTest.java
@@ -369,7 +369,7 @@ public class AspectModelJsonPayloadGeneratorTest extends MetaModelVersions {
       assertThat( aspectWithConstraints.getTestPropertyWithDecimalMaxRangeConstraint() ).isLessThanOrEqualTo( BigDecimal.valueOf( 10.5 ) );
       assertThat( aspectWithConstraints.getTestPropertyWithDecimalMinDecimalMaxRangeConstraint() ).isBetween( BigDecimal.valueOf( 2.3 ),
             BigDecimal.valueOf( 10.5 ) );
-      assertThat( aspectWithConstraints.getTestPropertyWithRegularExpression() ).matches( "^[a-zA-Z]" );
+      assertThat( aspectWithConstraints.getTestPropertyWithRegularExpression() ).matches( "^[a-zA-Z]\\.[0-9]" );
    }
 
    @ParameterizedTest

--- a/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/ConstraintAnnotationBuilder.java
+++ b/core/sds-aspect-model-java-generator/src/main/java/io/openmanufacturing/sds/aspectmodel/java/ConstraintAnnotationBuilder.java
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
  *
  * See the AUTHORS file(s) distributed with this work for additional
- * information regarding authorship. 
+ * information regarding authorship.
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -19,6 +19,8 @@ import java.util.Optional;
 import javax.validation.constraints.Digits;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
+
+import org.apache.commons.text.StringEscapeUtils;
 
 import io.openmanufacturing.sds.aspectmodel.java.rangeconstraint.AnnotationExpression;
 import io.openmanufacturing.sds.aspectmodel.java.rangeconstraint.AnnotationFactory;
@@ -71,7 +73,9 @@ public class ConstraintAnnotationBuilder {
          return;
       }
       final RegularExpressionConstraint regularExpressionConstraint = (RegularExpressionConstraint) constraintClass;
-      appendStringBuilder( Pattern.class, "regexp = \"" + regularExpressionConstraint.getValue() + "\"" );
+      final String value = regularExpressionConstraint.getValue();
+      final String escapedValue = StringEscapeUtils.escapeJava( value );
+      appendStringBuilder( Pattern.class, "regexp = \"" + escapedValue + "\"" );
    }
 
    private void createRangeConstraint() {
@@ -103,7 +107,7 @@ public class ConstraintAnnotationBuilder {
    private AnnotationExpression getAnnotationExpression( final Object value,
          final AnnotationTypeMapping annotationTypeMapping ) {
       return AnnotationFactory.getOperation( value.getClass(), annotationTypeMapping )
-                              .orElseThrow( () -> new IllegalArgumentException( "Invalid Annotation" ) );
+            .orElseThrow( () -> new IllegalArgumentException( "Invalid Annotation" ) );
    }
 
    private void createLengthConstraint() {
@@ -143,10 +147,10 @@ public class ConstraintAnnotationBuilder {
    private void appendStringBuilder( final Class<?> beanAnnotation, final Object expression ) {
       importTracker.importExplicit( beanAnnotation );
       constraintAnnotation.append( ANNOTATION_MARKING )
-                          .append( beanAnnotation.getSimpleName() )
-                          .append( LEFT_BRACKET )
-                          .append( expression )
-                          .append( RIGHT_BRACKET )
-                          .append( '\n' );
+            .append( beanAnnotation.getSimpleName() )
+            .append( LEFT_BRACKET )
+            .append( expression )
+            .append( RIGHT_BRACKET )
+            .append( '\n' );
    }
 }

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-static-class-property-lib.vm
@@ -277,7 +277,7 @@
         #set( $constraint = $RegularExpressionConstraint.cast( $characteristic ) )
         $codeGenerationConfig.getImportTracker().importExplicit( $DefaultRegularExpressionConstraint )
         new DefaultRegularExpressionConstraint( #getMetaModelBaseAttributes( $characteristic ),
-            "$constraint.getValue()" )
+            "$StringEscapeUtils.escapeJava( $constraint.getValue() )" )
     #elseif( $EncodingConstraint.isAssignableFrom( $characteristic.getClass() ) )
         #set( $constraint = $EncodingConstraint.cast( $characteristic ) )
         $codeGenerationConfig.getImportTracker().importExplicit( $DefaultEncodingConstraint )

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -270,7 +270,7 @@ public class AspectModelJavaGeneratorTest extends MetaModelVersions {
       result.assertNumberOfFiles( 1 );
       result.assertFields( "AspectWithConstraints", expectedFieldsForAspectClass,
             ImmutableMap.<String, String> builder()
-                  .put( "testPropertyWithRegularExpression", "@NotNull" + "@Pattern(regexp = \"^[a-zA-Z]\")" )
+                  .put( "testPropertyWithRegularExpression", "@NotNull" + "@Pattern(regexp = \"^[a-zA-Z]\\\\.[0-9]\")" )
                   .put( "testPropertyWithDecimalMinDecimalMaxRangeConstraint",
                         "@NotNull" + "@DecimalMin(value = \"2.3\")" + "@DecimalMax(value = \"10.5\")" )
                   .put( "testPropertyWithDecimalMaxRangeConstraint",

--- a/core/sds-test-aspect-models/src/main/resources/valid/bamm_1_0_0/io.openmanufacturing.test/1.0.0/AspectWithConstraints.ttl
+++ b/core/sds-test-aspect-models/src/main/resources/valid/bamm_1_0_0/io.openmanufacturing.test/1.0.0/AspectWithConstraints.ttl
@@ -34,7 +34,7 @@
    bamm:description "Test Regular Expression Constraint"@en ;
    bamm-c:constraint [
       a bamm-c:RegularExpressionConstraint ;
-      bamm:value "^[a-zA-Z]" ;
+      bamm:value "^[a-zA-Z]\\.[0-9]" ;
    ] ;
    bamm-c:baseCharacteristic bamm-c:Text .
 

--- a/core/sds-test-aspect-models/src/main/resources/valid/bamm_2_0_0/io.openmanufacturing.test/1.0.0/AspectWithConstraints.ttl
+++ b/core/sds-test-aspect-models/src/main/resources/valid/bamm_2_0_0/io.openmanufacturing.test/1.0.0/AspectWithConstraints.ttl
@@ -34,7 +34,7 @@
    bamm:description "Test Regular Expression Constraint"@en ;
    bamm-c:constraint [
       a bamm-c:RegularExpressionConstraint ;
-      bamm:value "^[a-zA-Z]" ;
+      bamm:value "^[a-zA-Z]\\.[0-9]" ;
    ] ;
    bamm-c:baseCharacteristic bamm-c:Text .
 


### PR DESCRIPTION
The regex literals for the Regular Expression Constraint are escaped in
the @Pattern annotation in the generated POJOs.

fixes #31