### PR TITLE
Fix code generation for Entity-Enum with langString

### DIFF
--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -880,4 +880,19 @@ public class AspectModelJavaGeneratorTest extends MetaModelVersions {
       result.assertClassDeclaration( "ExtendingTestEntity", Collections.emptyList(),
             Collections.singletonList( "AbstractTestEntity" ), Collections.emptyList(), Collections.emptyList() );
    }
+
+   @ParameterizedTest
+   @MethodSource( value = "versionsStartingWith2_0_0" )
+   public void testGenerateAspectModelWithEntityEnumerationAndLangString( final KnownVersion metaModelVersion ) throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY_ENUMERATION_AND_LANG_STRING;
+      final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, metaModelVersion, Optional.empty(), true ) );
+      result.assertNumberOfFiles( 3 );
+
+      final ImmutableMap<String, String> expectedConstantArguments = ImmutableMap.<String, String> builder()
+            .put( "ENTITY_INSTANCE",
+                  "new TestEntity(Map.of(Locale.forLanguageTag(\"de\"), \"Dies ist ein Test.\", Locale.forLanguageTag(\"en\"), \"This is a test.\"))" )
+            .build();
+
+      result.assertEnumConstants( "TestEnumeration", ImmutableSet.of( "ENTITY_INSTANCE" ), expectedConstantArguments );
+   }
 }


### PR DESCRIPTION
When an Entity with a language string property is used as the data type
of an Enum, the Enum constants were not generated correctly. In the
generation of the Enum constant a language string was treated in the
same manner as a string, causing an exception during the code
generation.

fixes #24