### PR TITLE
Include hashCode in generated POJOs

### DIFF
--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-class-body-lib.vm
@@ -2,6 +2,7 @@
 #parse( "java-pojo-constructor-lib.vm" )
 #parse( "java-pojo-getter-lib.vm" )
 #parse( "java-pojo-equals-method-lib.vm" )
+#parse( "java-pojo-hashcode-method-lib.vm" )
 
 #macro( javaPojoClassBody )
 /**
@@ -34,5 +35,7 @@ public class $element.getName() {
 #end
 
     #javaPojoEqualsMethod()
+
+    #javaPojoHashCodeMethod()
 }
 #end

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-equals-method-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-equals-method-lib.vm
@@ -7,6 +7,14 @@ if (this == o) {
 if (o == null || getClass() != o.getClass()) {
     return false;
 }
+#if ( $element.isComplex() )
+#set( $complexElement = $ComplexType.cast( $element ) )
+    #if ( $complexElement.getExtends().isPresent() )
+        if ( !super.equals( o ) ) {
+            return false;
+        }
+    #end
+#end
 final $element.getName() that = ($element.getName())o;
     return #foreach( $property in $element.getProperties() )
         Objects.equals(${property.getPayloadName()}, that.${property.getPayloadName()})

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-hashcode-method-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-hashcode-method-lib.vm
@@ -2,6 +2,12 @@
 @Override
 public int hashCode() {
     return Objects.hash(
+    #if ( $element.isComplex() )
+        #set( $complexElement = $ComplexType.cast( $element ) )
+        #if ( $complexElement.getExtends().isPresent() )
+            super.hashCode(),
+        #end
+    #end
     #foreach( $property in $element.getProperties() )
         ${property.getPayloadName()}
         #if( $foreach.hasNext) , #end

--- a/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-hashcode-method-lib.vm
+++ b/core/sds-aspect-model-java-generator/src/main/resources/java-pojo-hashcode-method-lib.vm
@@ -1,0 +1,11 @@
+#macro( javaPojoHashCodeMethod )
+@Override
+public int hashCode() {
+    return Objects.hash(
+    #foreach( $property in $element.getProperties() )
+        ${property.getPayloadName()}
+        #if( $foreach.hasNext) , #end
+    #end
+    );
+}
+#end

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -944,4 +944,69 @@ public class AspectModelJavaGeneratorTest extends MetaModelVersions {
 
       result.assertEnumConstants( "TestEnumeration", ImmutableSet.of( "ENTITY_INSTANCE" ), expectedConstantArguments );
    }
+
+   @ParameterizedTest
+   @MethodSource( value = "versionsStartingWith2_0_0" )
+   public void testGenerateEqualsForAspectWithAbstractEntity( final KnownVersion metaModelVersion ) throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ABSTRACT_ENTITY;
+      final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, metaModelVersion, Optional.empty(), true ) );
+
+      final PrimitiveType expectedReturnType = PrimitiveType.booleanType();
+      final boolean expectOverride = true;
+      final int expectedNumberOfParameters = 1;
+      List<String> expectedMethodBody = List.of(
+            "if(this==o){",
+            "returntrue;",
+            "}",
+            "if(o==null||getClass()!=o.getClass()){",
+            "returnfalse;",
+            "}",
+            "finalAspectWithAbstractEntitythat=(AspectWithAbstractEntity)o;",
+            "returnObjects.equals(testProperty,that.testProperty);" );
+      result.assertMethodBody( "AspectWithAbstractEntity", "equals", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+
+      expectedMethodBody = List.of(
+            "if(this==o){",
+            "returntrue;",
+            "}",
+            "if(o==null||getClass()!=o.getClass()){",
+            "returnfalse;",
+            "}",
+            "finalAbstractTestEntitythat=(AbstractTestEntity)o;",
+            "returnObjects.equals(abstractTestProperty,that.abstractTestProperty);" );
+      result.assertMethodBody( "AbstractTestEntity", "equals", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+
+      expectedMethodBody = List.of(
+            "if(this==o){",
+            "returntrue;",
+            "}",
+            "if(o==null||getClass()!=o.getClass()){",
+            "returnfalse;",
+            "}",
+            "if(!super.equals(o)){",
+            "returnfalse;",
+            "}",
+            "finalExtendingTestEntitythat=(ExtendingTestEntity)o;",
+            "returnObjects.equals(entityProperty,that.entityProperty);" );
+      result.assertMethodBody( "ExtendingTestEntity", "equals", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+   }
+
+   @ParameterizedTest
+   @MethodSource( value = "versionsStartingWith2_0_0" )
+   public void testGenerateHashCodeForAspectWithAbstractEntity( final KnownVersion metaModelVersion ) throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ABSTRACT_ENTITY;
+      final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, metaModelVersion, Optional.empty(), true ) );
+
+      final PrimitiveType expectedReturnType = PrimitiveType.intType();
+      final boolean expectOverride = true;
+      final int expectedNumberOfParameters = 0;
+      List<String> expectedMethodBody = List.of( "returnObjects.hash(testProperty);" );
+      result.assertMethodBody( "AspectWithAbstractEntity", "hashCode", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+
+      expectedMethodBody = List.of( "returnObjects.hash(abstractTestProperty);" );
+      result.assertMethodBody( "AbstractTestEntity", "hashCode", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+
+      expectedMethodBody = List.of( "returnObjects.hash(super.hashCode(),entityProperty);" );
+      result.assertMethodBody( "ExtendingTestEntity", "hashCode", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+   }
 }

--- a/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
+++ b/core/sds-aspect-model-java-generator/src/test/java/io/openmanufacturing/sds/aspectmodel/java/AspectModelJavaGeneratorTest.java
@@ -38,6 +38,7 @@ import com.github.javaparser.ast.Modifier;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.type.PrimitiveType;
 import com.github.javaparser.resolution.types.ResolvedArrayType;
 import com.github.javaparser.resolution.types.ResolvedPrimitiveType;
 import com.google.common.collect.ImmutableMap;
@@ -798,6 +799,54 @@ public class AspectModelJavaGeneratorTest extends MetaModelVersions {
       final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, metaModelVersion, Optional.empty(), true ) );
       result.assertNumberOfFiles( 1 );
       result.assertFields( "AspectWithBlankNode", expectedFieldsForAspectClass, new HashMap<>() );
+   }
+
+   @ParameterizedTest
+   @MethodSource( value = "allVersions" )
+   public void testGenerateEqualsForAspectWithEntity( final KnownVersion metaModelVersion ) throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
+      final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, metaModelVersion, Optional.empty(), true ) );
+
+      final PrimitiveType expectedReturnType = PrimitiveType.booleanType();
+      final boolean expectOverride = true;
+      final int expectedNumberOfParameters = 1;
+      List<String> expectedMethodBody = List.of(
+            "if(this==o){",
+            "returntrue;",
+            "}",
+            "if(o==null||getClass()!=o.getClass()){",
+            "returnfalse;",
+            "}",
+            "finalAspectWithEntitythat=(AspectWithEntity)o;",
+            "returnObjects.equals(testProperty,that.testProperty);" );
+      result.assertMethodBody( "AspectWithEntity", "equals", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+
+      expectedMethodBody = List.of(
+            "if(this==o){",
+            "returntrue;",
+            "}",
+            "if(o==null||getClass()!=o.getClass()){",
+            "returnfalse;",
+            "}",
+            "finalTestEntitythat=(TestEntity)o;",
+            "returnObjects.equals(entityProperty,that.entityProperty);" );
+      result.assertMethodBody( "TestEntity", "equals", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+   }
+
+   @ParameterizedTest
+   @MethodSource( value = "allVersions" )
+   public void testGenerateHashCodeForAspectWithEntity( final KnownVersion metaModelVersion ) throws IOException {
+      final TestAspect aspect = TestAspect.ASPECT_WITH_ENTITY;
+      final GenerationResult result = TestContext.generateAspectCode().apply( getGenerators( aspect, metaModelVersion, Optional.empty(), true ) );
+
+      final PrimitiveType expectedReturnType = PrimitiveType.intType();
+      final boolean expectOverride = true;
+      final int expectedNumberOfParameters = 0;
+      List<String> expectedMethodBody = List.of( "returnObjects.hash(testProperty);" );
+      result.assertMethodBody( "AspectWithEntity", "hashCode", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
+
+      expectedMethodBody = List.of( "returnObjects.hash(entityProperty);" );
+      result.assertMethodBody( "TestEntity", "hashCode", expectOverride, expectedReturnType, expectedNumberOfParameters, expectedMethodBody );
    }
 
    @ParameterizedTest


### PR DESCRIPTION
In addition to the equals method, the generated Java classes now contain
an implementation for the hashCode method.

fixes #35