### PR TITLE
Html documentation generation fails with quantifiable

### DIFF
--- a/core/sds-aspect-model-document-generators/src/main/resources/docu/templates/html/characteristic-documentation-lib.vm
+++ b/core/sds-aspect-model-document-generators/src/main/resources/docu/templates/html/characteristic-documentation-lib.vm
@@ -274,7 +274,9 @@ Characteristic specific macros will be joined together in the main macro (see ab
             <div class="table-cell pb-3 col-span-2">$duration.getDescription($i18n.getLocale())</div>
         </div>
     #end
-    #Unit($!duration.getUnit().get() $aspectModelHelper $i18n)
+    #if($!duration.getUnit().present)
+        #Unit($!duration.getUnit().get() $aspectModelHelper $i18n)
+    #end
 #end
 
 #* -- for Quantifiable ------------------------------------------------------------- *#

--- a/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/docu/AspectModelDocumentationGeneratorTest.java
+++ b/core/sds-aspect-model-document-generators/src/test/java/io/openmanufacturing/sds/aspectmodel/generator/docu/AspectModelDocumentationGeneratorTest.java
@@ -14,6 +14,7 @@
 package io.openmanufacturing.sds.aspectmodel.generator.docu;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -154,6 +155,14 @@ public class AspectModelDocumentationGeneratorTest extends MetaModelVersions {
       assertThat( documentation ).contains( "<h3 id=\"testProperty-property\">testProperty</h3>" );
       assertThat( documentation ).contains( "<h5 id=\"abstractTestProperty-property\">abstractTestProperty</h5>" );
       assertThat( documentation ).contains( "<h5 id=\"entityProperty-property\">entityProperty</h5>" );
+   }
+   @ParameterizedTest
+   @MethodSource( "allVersions" )
+   public void testAspectWithQuantifiableWithoutUnit( final KnownVersion metaModelVersion ) throws IOException {
+      try ( final ByteArrayOutputStream stdOut = new ByteArrayOutputStream() ) {
+         System.setOut( new PrintStream( stdOut ) );
+         assertDoesNotThrow( () -> generateHtmlDocumentation( TestAspect.ASPECT_WITH_QUANTIFIABLE_WITHOUT_UNIT, metaModelVersion ) );
+      }
    }
 
    private String generateHtmlDocumentation( final TestAspect model, final KnownVersion testedVersion ) throws IOException {


### PR DESCRIPTION
Added If-clause to check if unit is existing
Added testcase for new if-check

Solves #96 