### PR TITLE
Update equals method for DefaultPropertyWrapper

### DIFF
--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/impl/DefaultProperty.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/impl/DefaultProperty.java
@@ -140,7 +140,9 @@ public class DefaultProperty extends BaseImpl implements Property {
          return false;
       }
       final DefaultProperty that = (DefaultProperty) o;
-      return optional == that.optional &&
+      return Objects.equals( getName(), that.getName() ) &&
+            Objects.equals( getAspectModelUrn(), that.getAspectModelUrn() ) &&
+            optional == that.optional &&
             notInPayload == that.notInPayload &&
             isAbstract == that.isAbstract &&
             Objects.equals( characteristic, that.characteristic ) &&

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
@@ -22,8 +22,9 @@ import io.openmanufacturing.sds.metamodel.impl.DefaultProperty;
 
 public class DefaultPropertyWrapper extends DefaultProperty {
    private DefaultProperty property;
+
    public DefaultPropertyWrapper( MetaModelBaseAttributes metaModelBaseAttributes ) {
-      super(metaModelBaseAttributes, null,null, false, false, null, false, null);
+      super( metaModelBaseAttributes, null, null, false, false, null, false, null );
    }
 
    @Override
@@ -63,7 +64,7 @@ public class DefaultPropertyWrapper extends DefaultProperty {
 
    @Override
    public boolean equals( final Object o ) {
-      if(o != null)
+      if ( o != null )
          return o.equals( property );
       return false;
    }
@@ -72,8 +73,8 @@ public class DefaultPropertyWrapper extends DefaultProperty {
    public int hashCode() {
       return property.hashCode();
    }
-   public void setProperty(DefaultProperty property)
-   {
+
+   public void setProperty( DefaultProperty property ) {
       this.property = property;
    }
 }

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
@@ -23,106 +23,57 @@ import io.openmanufacturing.sds.metamodel.impl.DefaultCharacteristic;
 import io.openmanufacturing.sds.metamodel.impl.DefaultProperty;
 
 public class DefaultPropertyWrapper extends DefaultProperty {
-
-   private Optional<Characteristic> characteristic;
-   private Optional<ScalarValue> exampleValue;
-   private boolean optional;
-   private boolean notInPayload;
-   private boolean isAbstract;
-   private Optional<Property> extends_;
-   private Optional<String> payloadName;
-
-   public DefaultPropertyWrapper( final MetaModelBaseAttributes metaModelBaseAttributes ) {
-      super( metaModelBaseAttributes, Optional.of( new DefaultCharacteristic( metaModelBaseAttributes, Optional.empty() ) ),
-            Optional.empty(), false, false, Optional.empty(), false, Optional.empty() );
+   private DefaultProperty property;
+   public DefaultPropertyWrapper( ) {
+      super(null, null,null, false, false, null, false, null);
    }
 
    @Override
    public String getPayloadName() {
-      return payloadName.orElseGet( this::getName );
-   }
-
-   public void setPayloadName( final Optional<String> payloadName ) {
-      this.payloadName = payloadName;
+      return property.getPayloadName();
    }
 
    @Override
    public Optional<ScalarValue> getExampleValue() {
-      return exampleValue;
-   }
-
-   public void setExampleValue( final Optional<ScalarValue> exampleValue ) {
-      this.exampleValue = exampleValue;
+      return property.getExampleValue();
    }
 
    @Override
    public boolean isNotInPayload() {
-      return notInPayload;
-   }
-
-   public void setNotInPayload( final boolean notInPayload ) {
-      this.notInPayload = notInPayload;
+      return property.isNotInPayload();
    }
 
    @Override
    public boolean isOptional() {
-      return optional;
-   }
-
-   public void setOptional( final boolean optional ) {
-      this.optional = optional;
+      return property.isOptional();
    }
 
    @Override
    public boolean isAbstract() {
-      return isAbstract;
-   }
-
-   public void setAbstract( final boolean isAbstract ) {
-      this.isAbstract = isAbstract;
+      return property.isAbstract();
    }
 
    @Override
    public Optional<Property> getExtends() {
-      return extends_;
-   }
-
-   public void setExtends_( final Optional<Property> extends_ ) {
-      this.extends_ = extends_;
+      return property.getExtends();
    }
 
    @Override
    public Optional<Characteristic> getCharacteristic() {
-      return characteristic;
+      return property.getCharacteristic();
    }
 
-   public void setCharacteristic( final Characteristic characteristic ) {
-      this.characteristic = Optional.of( characteristic );
-   }
-
-   @SuppressWarnings( "squid:S1067" )
-   // Shall be the same as in super class just without calling super due to possible recursive dependencies
    @Override
    public boolean equals( final Object o ) {
-      if ( this == o ) {
-         return true;
-      }
-      if ( o == null || getClass() != o.getClass() ) {
-         return false;
-      }
-      final DefaultPropertyWrapper that = (DefaultPropertyWrapper) o;
-      return Objects.equals( getName(), that.getName() ) &&
-            Objects.equals( getAspectModelUrn(), that.getAspectModelUrn() ) &&
-            optional == that.optional &&
-            notInPayload == that.notInPayload &&
-            isAbstract == that.isAbstract &&
-            Objects.equals( extends_, that.extends_ ) &&
-            Objects.equals( characteristic, that.characteristic ) &&
-            Objects.equals( exampleValue, that.exampleValue );
+      return property.equals( o );
    }
 
    @Override
    public int hashCode() {
-      return Objects.hash( super.hashCode(), exampleValue, optional, notInPayload, isAbstract, extends_ );
+      return property.hashCode();
+   }
+   public void setProperty(DefaultProperty property)
+   {
+      this.property = property;
    }
 }

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
@@ -13,19 +13,17 @@
 
 package io.openmanufacturing.sds.metamodel.loader;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import io.openmanufacturing.sds.metamodel.Characteristic;
 import io.openmanufacturing.sds.metamodel.Property;
 import io.openmanufacturing.sds.metamodel.ScalarValue;
-import io.openmanufacturing.sds.metamodel.impl.DefaultCharacteristic;
 import io.openmanufacturing.sds.metamodel.impl.DefaultProperty;
 
 public class DefaultPropertyWrapper extends DefaultProperty {
    private DefaultProperty property;
-   public DefaultPropertyWrapper( ) {
-      super(null, null,null, false, false, null, false, null);
+   public DefaultPropertyWrapper( MetaModelBaseAttributes metaModelBaseAttributes ) {
+      super(metaModelBaseAttributes, null,null, false, false, null, false, null);
    }
 
    @Override
@@ -65,7 +63,9 @@ public class DefaultPropertyWrapper extends DefaultProperty {
 
    @Override
    public boolean equals( final Object o ) {
-      return property.equals( o );
+      if(o != null)
+         return o.equals( property );
+      return false;
    }
 
    @Override

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/DefaultPropertyWrapper.java
@@ -111,7 +111,9 @@ public class DefaultPropertyWrapper extends DefaultProperty {
          return false;
       }
       final DefaultPropertyWrapper that = (DefaultPropertyWrapper) o;
-      return optional == that.optional &&
+      return Objects.equals( getName(), that.getName() ) &&
+            Objects.equals( getAspectModelUrn(), that.getAspectModelUrn() ) &&
+            optional == that.optional &&
             notInPayload == that.notInPayload &&
             isAbstract == that.isAbstract &&
             Objects.equals( extends_, that.extends_ ) &&

--- a/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/instantiator/PropertyInstantiator.java
+++ b/core/sds-aspect-meta-model-java/src/main/java/io/openmanufacturing/sds/metamodel/loader/instantiator/PropertyInstantiator.java
@@ -60,7 +60,7 @@ public class PropertyInstantiator extends Instantiator<Property> {
       final boolean isAbstract = property.getModel().contains( property, RDF.type, bamm.AbstractProperty() );
 
       final MetaModelBaseAttributes metaModelBaseAttributes = buildBaseAttributes( property );
-      final DefaultPropertyWrapper defaultPropertyWrapper = new DefaultPropertyWrapper( );
+      final DefaultPropertyWrapper defaultPropertyWrapper = new DefaultPropertyWrapper( metaModelBaseAttributes);
 
       if ( resourcePropertyMap.containsKey( property ) ) {
          final Property propertyInstance = resourcePropertyMap.get( property );

--- a/core/sds-aspect-meta-model-version-migrator/src/main/java/io/openmanufacturing/sds/aspectmodel/versionupdate/MigratorService.java
+++ b/core/sds-aspect-meta-model-version-migrator/src/main/java/io/openmanufacturing/sds/aspectmodel/versionupdate/MigratorService.java
@@ -67,7 +67,6 @@ public class MigratorService {
     * which is then applied to the given source model.
     *
     * @param versionedModel the source model
-    * @param targetVersion the target meta model version
     * @return the resulting {@link VersionedModel} that corresponds to the input Aspect model, but with the new meta model version
     */
    public Try<VersionedModel> updateMetaModelVersion( final VersionedModel versionedModel ) {

--- a/core/sds-aspect-model-resolver/src/test/java/io/openmanufacturing/sds/aspectmodel/resolver/AspectModelResolverTest.java
+++ b/core/sds-aspect-model-resolver/src/test/java/io/openmanufacturing/sds/aspectmodel/resolver/AspectModelResolverTest.java
@@ -17,6 +17,7 @@ import static org.assertj.vavr.api.VavrAssertions.assertThat;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.net.URISyntaxException;
 
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.RDFNode;
@@ -42,10 +43,11 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testLoadDataModelExpectSuccess( final KnownVersion metaModelVersion ) {
+   public void testLoadDataModelExpectSuccess( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader()
                                          .getResource( metaModelVersion.toString().toLowerCase() )
+                                         .toURI()
                                          .getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn.fromUrn( "urn:bamm:io.openmanufacturing.test:1.0.0#Test" );
@@ -68,10 +70,11 @@ public class AspectModelResolverTest extends MetaModelVersions {
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
    public void testLoadModelWithVersionEqualToUnsupportedMetaModelVersionExpectSuccess(
-         final KnownVersion metaModelVersion ) {
+         final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader()
                                          .getResource( metaModelVersion.toString().toLowerCase() )
+                                         .toURI()
                                          .getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn.fromUrn( "urn:bamm:io.openmanufacturing.test:1.1.0#Test" );
@@ -93,10 +96,10 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testResolveReferencedModelFromMemoryExpectSuccess( final KnownVersion metaModelVersion ) {
+   public void testResolveReferencedModelFromMemoryExpectSuccess( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final ResolutionStrategy urnStrategy = new FileSystemStrategy( aspectModelsRootDirectory.toPath() );
       final AspectModelUrn inputUrn = AspectModelUrn
@@ -134,10 +137,10 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testResolveReferencedModelExpectSuccess( final KnownVersion metaModelVersion ) {
+   public void testResolveReferencedModelExpectSuccess( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn
             .fromUrn( "urn:bamm:io.openmanufacturing.test:aspect-model:AnotherTest:1.0.0" );
@@ -170,10 +173,11 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testResolutionMissingAspectExpectFailure( final KnownVersion metaModelVersion ) {
+   public void testResolutionMissingAspectExpectFailure( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader()
                                          .getResource( metaModelVersion.toString().toLowerCase() )
+                                         .toURI()
                                          .getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn
@@ -190,7 +194,7 @@ public class AspectModelResolverTest extends MetaModelVersions {
    public void testResolutionMissingModelElementExpectFailure( final KnownVersion metaModelVersion ) throws Throwable {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn
             .fromUrn( "urn:bamm:io.openmanufacturing.test:1.0.0#FailingTest" );
@@ -205,10 +209,10 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testResolutionReferencedCharacteristicExpectSuccess( final KnownVersion metaModelVersion ) {
+   public void testResolutionReferencedCharacteristicExpectSuccess( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn
             .fromUrn( "urn:bamm:io.openmanufacturing.test:1.0.0#ReferenceCharacteristicTest" );
@@ -255,7 +259,7 @@ public class AspectModelResolverTest extends MetaModelVersions {
    public void testTransitiveReferenceExpectSuccess( final KnownVersion metaModelVersion ) throws Throwable {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn
             .fromUrn( "urn:bamm:io.openmanufacturing.test:1.0.0#TransitiveReferenceTest" );
@@ -275,10 +279,10 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testResolutionReferencedEntity( final KnownVersion metaModelVersion ) {
+   public void testResolutionReferencedEntity( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final AspectModelUrn testUrn = AspectModelUrn
             .fromUrn( "urn:bamm:io.openmanufacturing.test:1.0.0#ReferenceEntityTest" );
@@ -313,10 +317,10 @@ public class AspectModelResolverTest extends MetaModelVersions {
 
    @ParameterizedTest
    @MethodSource( value = "allVersions" )
-   public void testAspectReferencingAnotherAspectExpectSuccess( final KnownVersion metaModelVersion ) {
+   public void testAspectReferencingAnotherAspectExpectSuccess( final KnownVersion metaModelVersion ) throws URISyntaxException {
       final File aspectModelsRootDirectory = new File(
             AspectModelResolverTest.class.getClassLoader().getResource( metaModelVersion.toString().toLowerCase() )
-                                         .getPath() );
+                                         .toURI().getPath() );
 
       final String aspectUrn = "urn:bamm:io.openmanufacturing.test:2.0.0#Test";
       final AspectModelUrn testUrn = AspectModelUrn.fromUrn( aspectUrn );


### PR DESCRIPTION
The equals method in the DefaultPropertyWrapper class did not consider
the name and urn of the property.

fixes #170