### PR TITLE
fix link in README.md

### DIFF
--- a/tools/bamm-cli/README.md
+++ b/tools/bamm-cli/README.md
@@ -1,4 +1,5 @@
 # BAMM Aspect Meta Model Command Line Interface
 
 The BAMM CLI bundles the functionality provided in the SDS SDK in a CLI application to be used in you terminal for ad-hoc usage outside an IDE.
-For details on the usage and offered functionalities see the [documentation](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/dev-snapshot/tooling-guide/bamm-cli.html).
+For details on the usage and offered functionalities see the [documentation](https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/tooling-guide/bamm-cli.html).
+


### PR DESCRIPTION
link in Readme to CLI documentation does not work, updated with https://openmanufacturingplatform.github.io/sds-documentation/sds-developer-guide/tooling-guide/bamm-cli.html