### PR TITLE
Updates apache commons-text due to CVE-2022-42889

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
       <aspect-meta-model-version>2.0.0</aspect-meta-model-version>
       <assertj-vavr-version>0.4.2</assertj-vavr-version>
       <classgraph-version>4.8.146</classgraph-version>
-      <commons-text-version>1.9</commons-text-version>
+      <commons-text-version>1.10.0</commons-text-version>
       <easy-random-version>5.0.0</easy-random-version>
       <graphviz-version>0.18.1</graphviz-version>
       <guava-version>31.1-jre</guava-version>


### PR DESCRIPTION
Updates Apache commons-text due to CVE-2022-42889
fixes #238 