### PR TITLE
Fix package signing configuration

### DIFF
--- a/.github/workflows/pull_request_check.yml
+++ b/.github/workflows/pull_request_check.yml
@@ -16,4 +16,4 @@ jobs:
         distribution: 'temurin'
         java-version: '17'
     - name: Run tests
-      run: mvn -B clean install
+      run: mvn -B clean install -Dgpg.skip=true

--- a/.github/workflows/release-workflow.yml
+++ b/.github/workflows/release-workflow.yml
@@ -67,7 +67,7 @@ jobs:
             git push origin ${{ env.release_branch_name }}
           fi
       - name: Run tests and build
-        run: mvn -B clean install
+        run: mvn -B clean install -Dgpg.skip=true
 
       # release-build
       - name: Create GitHub release

--- a/pom.xml
+++ b/pom.xml
@@ -616,7 +616,7 @@
             <executions>
                <execution>
                   <id>sign-artifacts</id>
-                  <phase>deploy</phase>
+                  <phase>verify</phase>
                   <goals>
                      <goal>sign</goal>
                   </goals>


### PR DESCRIPTION
Since the update of the nexus-staging-maven-plugin, the artifacts need to be
explicitly signed _before_ they are uploaded to OSSRH. Without this fix, an
OSSRH release is not possible since the signature files are missing.